### PR TITLE
Reensure when $invalidating async derived properties, add…

### DIFF
--- a/src/derived.js
+++ b/src/derived.js
@@ -133,9 +133,13 @@ class AsyncDerivedValue extends CachedDerivedValue {
     this.$$promise = Symbol('promise')
   }
 
-  clearCache (object) {
-    delete object[this.$$cache]
-    delete object[this.$$promise]
+  clearCache (object, reensure = false) {
+    if (reensure) {
+      this.ensure(object, null, true)
+    } else {
+      delete object[this.$$cache]
+      delete object[this.$$promise]
+    }
   }
 
   force (object, value) {
@@ -160,7 +164,7 @@ class AsyncDerivedValue extends CachedDerivedValue {
 
   update (object, changeset) {
     if (this.fetched(object) && this.options.reensure !== false) {
-      this.ensure(object, changeset)
+      this.ensure(object, changeset, true)
     } else {
       this.clearCache(object)
     }
@@ -170,9 +174,9 @@ class AsyncDerivedValue extends CachedDerivedValue {
     return object.hasOwnProperty(this.$$cache)
   }
 
-  ensure (object, changeset) {
+  ensure (object, changeset, force = false) {
     let derived = this
-    if (object.hasOwnProperty(derived.$$promise)) {
+    if (!force && object.hasOwnProperty(derived.$$promise)) {
       return object[derived.$$promise]
     }
     let result = this.getter.call(object, object[this.$$cache], changeset)

--- a/src/model.js
+++ b/src/model.js
@@ -635,7 +635,7 @@ function generateModel (name) {
         if (derived == null || !(derived instanceof DerivedValue.Cached)) {
           throw new Error(`$invalidate was called for a property that wasn't a cached derived value: ${name}`)
         }
-        derived.clearCache(this)
+        derived.clearCache(this, true)
       }
     },
 
@@ -645,7 +645,7 @@ function generateModel (name) {
         if (derived == null || !(derived instanceof DerivedValue.Cached)) {
           throw new Error(`$clear was called for a property that wasn't a cached derived value: ${name}`)
         }
-        derived.clearCache(this, false)
+        derived.clearCache(this)
       }
     },
 


### PR DESCRIPTION
… force option to async property’s ensure method which will also reensure instead of returning the already revolved value