### PR TITLE
Add `new` method, $isNew now defaults to false

### DIFF
--- a/spec/protocols/queryable_spec.js
+++ b/spec/protocols/queryable_spec.js
@@ -32,6 +32,13 @@ describe('A model defined with a storage implementation', function () {
       flow.resolve(new Protocol.Queryable.Success(true))
     })
 
+  it('should be able to create an instance with Person.new()', function (done) {
+    let object = Person.new({nas: '1', firstName: 'John', lastName: 'Smith'})
+    expect(object.firstName).toBe('John')
+    expect(object.$isNew).toBe(true)
+    done()
+  })
+
   it('should be able to create and store data for an instance with Person.create()', function (done) {
     Person.create({nas: '1', firstName: 'John', lastName: 'Smith'}).then(function (object) {
       expect(storage['1'].firstName).toBe('John')

--- a/src/protocols/queryable.js
+++ b/src/protocols/queryable.js
@@ -179,7 +179,7 @@ const Queryable = Protocol('Queryable')
     model.prototype.$save = doSave
     Object.defineProperty(model.prototype, '$isNew', {
       get: function () {
-        return this[$$isNew] == null || this[$$isNew] === true
+        return this[$$isNew] === true
       },
       set: function (isNew) {
         this[$$isNew] = (isNew === true)

--- a/src/protocols/queryable.js
+++ b/src/protocols/queryable.js
@@ -102,21 +102,19 @@ function doDelete (...args) {
   })
 }
 
-function doCreate (...args) {
-  let options = args.pop()
-  if (options.autoSave == null) {
-    args.push(options)
-    options = {autoSave: true}
-  }
+function doNew (...args) {
   let object = Reflect.construct(this, args)
-  if (options.autoSave === true) {
-    let promise = object.$save().then(function (resp) {
-      return object
-    })
-    promise.$result = object
-    return promise
-  }
+  object.$isNew = true
   return object
+}
+
+function doCreate (...args) {
+  let object = this.new(args)
+  let promise = object.$save().then(function (resp) {
+    return object
+  })
+  promise.$result = object
+  return promise
 }
 
 function doSave (...args) {
@@ -175,6 +173,7 @@ const Queryable = Protocol('Queryable')
     model.prototype.$remove = doDelete
   })
   .method('store', {mode: 'async_flow'}, function (model) {
+    model.new = doNew
     model.create = doCreate
     model.prototype.$save = doSave
     Object.defineProperty(model.prototype, '$isNew', {


### PR DESCRIPTION
Fixes #15, fixes #16

@matehat Took the liberty of removing the `args.pop` bit from `create()` as it would eat the instance's attributes when no options we're passed. Considering `new` now does what `create()` did with `autoSave: false`, I feel like this is the correct approach. Feel free to say no! 😆

Havn't bumped the version yet.