### PR TITLE
`instanceof Symbol` not returning true even when the `property` is a …

### DIFF
--- a/src/collection/map_collection.js
+++ b/src/collection/map_collection.js
@@ -80,7 +80,7 @@ class MapCollection {
         }
       },
       deleteProperty: function (target, property) {
-        if (property instanceof Symbol) {
+        if (typeof property === 'symbol') {
           delete target[property]
           return true
         }


### PR DESCRIPTION
…`Symbol`

Because of this, removing a symbol for a map_collection would never actually work.